### PR TITLE
Add RestHelper and endpoint-specific withCredentials

### DIFF
--- a/src/app/services/EndpointService.js
+++ b/src/app/services/EndpointService.js
@@ -22,6 +22,7 @@
       config.selectedEndpoint = endpoint;
       config.nflowUrl = endpoint.apiUrl;
       config.nflowApiDocs = endpoint.docUrl;
+      config.withCredentials = endpoint.withCredentials;
 
       try {
         $window.localStorage.setItem('nflow.endpoint', endpoint.id);

--- a/src/app/services/ExecutorService.js
+++ b/src/app/services/ExecutorService.js
@@ -2,9 +2,10 @@
   'use strict';
   var m = angular.module('nflowExplorer.services.ExecutorService', [
     'nflowExplorer.config',
+    'nflowExplorer.services.RestHelper',
   ]);
 
-  m.service('ExecutorService', function ExecutorService(config, $http, $interval) {
+  m.service('ExecutorService', function ExecutorService(config, RestHelper, $interval) {
     var started = false;
 
     var api = this;
@@ -13,11 +14,7 @@
     api.executors = [];
 
     function list() {
-      return $http({
-        url: config.nflowUrl + '/v1/workflow-executor'
-      }).then(function (response) {
-        return response.data;
-      });
+      return RestHelper.query({path: '/v1/workflow-executor'});
     }
 
     function start() {

--- a/src/app/services/GraphService.js
+++ b/src/app/services/GraphService.js
@@ -1,13 +1,15 @@
 (function () {
   'use strict';
 
-  var m = angular.module('nflowExplorer.services.GraphService', []);
+  var m = angular.module('nflowExplorer.services.GraphService', [
+    'nflowExplorer.config',
+  ]);
 
-  m.service('GraphService', function GraphServiceFactory($q, $http, $rootScope) {
+  m.service('GraphService', function GraphServiceFactory(config, $q, $http, $rootScope) {
     this.loadCss = function getCss() {
       var defer = $q.defer();
       // links are relative to displayed page
-      $http.get('styles/data/graph.css')
+      $http.get('styles/data/graph.css', {withCredentials: !!config.withCredentials})
         .success(function(data) {
           $rootScope.graph = {};
           $rootScope.graph.css=data;

--- a/src/app/services/RestHelper.js
+++ b/src/app/services/RestHelper.js
@@ -1,0 +1,43 @@
+(function () {
+  'use strict';
+  var m = angular.module('nflowExplorer.services.RestHelper', [
+    'nflowExplorer.config',
+    'ngResource',
+  ]);
+
+  m.factory('RestHelper', function RestHelper(config, $resource) {
+    var helpers = {};
+
+    helpers.query = function (query, params) {
+      return $resource(config.nflowUrl + query.path, params, {
+        'query': {
+          method: 'GET',
+          isArray: true,
+          cache: query.cache,
+          withCredentials: !!config.withCredentials
+        }
+      }).query().$promise;
+    };
+
+    helpers.get = function (query, params, paramDefaults) {
+      return $resource(config.nflowUrl + query.path, paramDefaults, {
+        'query': {
+          method: 'GET',
+          cache: query.cache,
+          withCredentials: !!config.withCredentials
+        }
+      }).get(params).$promise;
+    };
+
+    helpers.update = function (path, data) {
+      return $resource(config.nflowUrl + path, null, {
+        'update': {
+          method: 'PUT',
+          withCredentials: !!config.withCredentials
+        }
+      }).update(data).$promise;
+    };
+
+    return helpers;
+  });
+})();

--- a/src/app/services/WorkflowDefinitionService.js
+++ b/src/app/services/WorkflowDefinitionService.js
@@ -2,40 +2,35 @@
   'use strict';
 
   var m = angular.module('nflowExplorer.services.WorkflowDefinitionService', [
-    'ngResource',
+    'nflowExplorer.services.RestHelper',
   ]);
 
-  m.service('WorkflowDefinitionService', function WorkflowDefinitionService(config, $resource, $http, $cacheFactory) {
+  m.service('WorkflowDefinitionService', function WorkflowDefinitionService(config, RestHelper, $cacheFactory) {
     var api = this;
     api.get = get;
     api.list = list;
     api.getStats = getStats;
 
     var getCache = $cacheFactory('workflow-definition');
-    function get(type) {
-      var resource = $resource(config.nflowUrl + '/v1/workflow-definition',
-        {type: '@type'},
-        {'get': {isArray: true,
-          method:  'GET',
-          cache: getCache} });
 
-      return resource.get({type: type}).$promise;
+    function get(type) {
+      return RestHelper.query({
+        path: '/v1/workflow-definition',
+        cache: getCache
+      }, {type: type});
     }
 
     var listCache = $cacheFactory('workflow-definition-list');
-    function list() {
-      var resource = $resource(config.nflowUrl + '/v1/workflow-definition',
-        {type: '@type'},
-        {'query': {isArray: true,
-          method:  'GET',
-          cache: listCache} });
 
-      return resource.query().$promise;
+    function list() {
+      return RestHelper.query({
+        path: '/v1/workflow-definition',
+        cache: listCache
+      });
     }
 
     function getStats(type) {
-      var stats = $resource(config.nflowUrl + '/v1/statistics/workflow/:type', {type: '@type'});
-      return stats.get({type: type}).$promise;
+      return RestHelper.get({path: '/v1/statistics/workflow/:type'}, {type: type}, {type: '@type'});
     }
 
   });

--- a/src/app/services/WorkflowService.js
+++ b/src/app/services/WorkflowService.js
@@ -3,10 +3,10 @@
 
   var m = angular.module('nflowExplorer.services.WorkflowService', [
     'nflowExplorer.config',
-    'ngResource'
+    'nflowExplorer.services.RestHelper',
   ]);
 
-  m.service('WorkflowService', function WorkflowService(config, $http, $resource) {
+  m.service('WorkflowService', function WorkflowService(config, RestHelper) {
     var api = this;
     api.get = get;
     api.update = update;
@@ -14,36 +14,21 @@
     api.signal = signal;
 
     function get(workflowId) {
-      return $http({
-        url: config.nflowUrl + '/v1/workflow-instance/' + workflowId + '?include=actions,currentStateVariables,actionStateVariables',
-      }).then(function(response) {
-        return response.data;
+      return RestHelper.get({
+        path: '/v1/workflow-instance/' + workflowId + '?include=actions,currentStateVariables,actionStateVariables'
       });
     }
 
     function update(workflowId, data) {
-      return $http({
-        url: config.nflowUrl + '/v1/workflow-instance/' + workflowId,
-        method: 'PUT',
-        data: data,
-      }).then(function(response) {
-        return response.data;
-      });
+      return RestHelper.update('/v1/workflow-instance/' + workflowId, data);
     }
 
     function signal(workflowId, data) {
-      return $http({
-        url: config.nflowUrl + '/v1/workflow-instance/' + workflowId + '/signal',
-        method: 'PUT',
-        data: data,
-      }).then(function(response) {
-        return response.data;
-      });
+      return RestHelper.update('/v1/workflow-instance/' + workflowId + '/signal', data);
     }
 
     function query(queryCriteria) {
-      var resource = $resource(config.nflowUrl + '/v1/workflow-instance');
-      return resource.query(queryCriteria).$promise;
+      return RestHelper.query({path: '/v1/workflow-instance'}, queryCriteria);
     }
 
   });

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,7 @@ var Config = function() {
   // these get overwritten in EndpointService
   this.nflowUrl = 'http://localhost:7500/api/nflow';
   this.nflowApiDocs = 'http://localhost:7500/doc/';
+  this.withCredentials = false;
 
   this.nflowEndpoints = [
     {

--- a/src/index.html
+++ b/src/index.html
@@ -98,6 +98,7 @@
     <script src="app/search/searchResult.js"></script>
 
     <script src="app/services/index.js"></script>
+    <script src="app/services/RestHelper.js"></script>
     <script src="app/services/EndpointService.js"></script>
     <script src="app/services/ExecutorService.js"></script>
     <script src="app/services/GraphService.js"></script>


### PR DESCRIPTION
- Consolidate REST client configuration to ```RestHelper```
- Endpoint-specific ```withCredentials``` parameter so that e.g. basic authentication credentials or cookies can be propagated to AJAX-requests